### PR TITLE
Swift 3, iOS 10 check, Add NS strings

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -10,7 +10,10 @@
   <keywords>cordova, speech-recognition, iOS, Siri API</keywords>
   <repo></repo>
   <issue></issue>
-
+  
+  <engines>
+      <engine name="cordova" version=">=3.4.0" />
+  </engines>
   <js-module src="www/SpeechRecognitionFeatSiri.js" name="SpeechRecognitionFeatSiri">
     <clobbers target="SpeechRecognitionFeatSiri" />
   </js-module>

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,12 +17,22 @@
 
   <!-- ios -->
   <platform name="ios">
+    <preference name="SPEECH_USAGE_DESCRIPTION" default="Speech recognition permission is required" />
+    <preference name="MICROPHONE_USAGE_DESCRIPTION" default="Microphone permission is required for speech recognition" />
     <config-file target="config.xml" parent="/*">
       <feature name="SpeechRecognitionFeatSiri">
         <param name="ios-package" value="CDVSpeechRecognition"/>
         <param name="onload" value="true" />
       </feature>
     </config-file>
+    
+    <config-file target="*-Info.plist" parent="NSSpeechRecognitionUsageDescription">
+        <string>$SPEECH_USAGE_DESCRIPTION</string>
+    </config-file>
+    <config-file target="*-Info.plist" parent="NSMicrophoneUsageDescription">
+        <string>$MICROPHONE_USAGE_DESCRIPTION</string>
+    </config-file>
+
     <source-file src="src/ios/CDVSpeechRecognition.swift" />
     <source-file src="src/ios/CDVSpeechRecognitionViewController.swift" />
   </platform>

--- a/src/ios/CDVSpeechRecognition.swift
+++ b/src/ios/CDVSpeechRecognition.swift
@@ -86,6 +86,6 @@
      - return systen locale identifer (ex. "ja-JP", "en-US"...)
     */
     func currentLocaleIdentifer() -> String {
-        return NSLocale.current.identifier.replacingOccurrences(of: "_", with: "-")
+        return Locale.current.identifier.replacingOccurrences(of: "_", with: "-")
     }
 }

--- a/src/ios/CDVSpeechRecognition.swift
+++ b/src/ios/CDVSpeechRecognition.swift
@@ -6,6 +6,7 @@
  
    copyright (C) 2016 - 2017 SOHKAKUDO Ltd. All Rights Reserved.
  */
+@available(iOS 10.0, *)
 @objc(CDVSpeechRecognition) class SpeechRecognition : CDVPlugin, TimeOutDelegate, OnFinalDelegate {
 
     fileprivate var srvc : CDVSpeechRecognitionViewController = CDVSpeechRecognitionViewController()

--- a/src/ios/CDVSpeechRecognitionViewController.swift
+++ b/src/ios/CDVSpeechRecognitionViewController.swift
@@ -81,20 +81,6 @@ open class CDVSpeechRecognitionViewController: UIViewController, SFSpeechRecogni
     func setup() {
         audioEngine = AVAudioEngine()
         self.initializeAVAudioSession()
-        SFSpeechRecognizer.requestAuthorization { authStatus in
-            OperationQueue.main.addOperation {
-                switch authStatus {
-                    case .authorized:
-                        self.status = "authorized"
-                    case .denied:
-                        self.status = "denied"
-                    case .restricted:
-                        self.status = "restricted"
-                    case .notDetermined:
-                        self.status = "notDetermined"
-                }
-            }
-        }
     }
     
     /**
@@ -110,6 +96,22 @@ open class CDVSpeechRecognitionViewController: UIViewController, SFSpeechRecogni
      - return This Plugin's Status: true -> Plugin is Enable, false -> Plugin is Disabled.  
      */
     open func isEnabled() -> Bool {
+        if (self.status != "authorized") {
+            SFSpeechRecognizer.requestAuthorization { authStatus in
+                OperationQueue.main.addOperation {
+                    switch authStatus {
+                        case .authorized:
+                            self.status = "authorized"
+                        case .denied:
+                            self.status = "denied"
+                        case .restricted:
+                            self.status = "restricted"
+                        case .notDetermined:
+                            self.status = "notDetermined"
+                    }
+                }
+            }            
+        }
         return self.status == "authorized"
     }
 

--- a/src/ios/CDVSpeechRecognitionViewController.swift
+++ b/src/ios/CDVSpeechRecognitionViewController.swift
@@ -21,6 +21,7 @@ protocol OnFinalDelegate {
     func onFinal(_ ret: String)
 }
 
+@available(iOS 10.0, *)
 open class CDVSpeechRecognitionViewController: UIViewController, SFSpeechRecognizerDelegate, SFSpeechRecognitionTaskDelegate {
 
     // MARK: Properties


### PR DESCRIPTION
Convert the code to Swift 3
Add available checks to compile for targets lower than iOS 10
Add NSMicrophoneUsageDescription and NSSpeechRecognitionUsageDescription to plugin.xml to automatically include in the plist.info